### PR TITLE
Fix Windows library search

### DIFF
--- a/FindTBB.cmake
+++ b/FindTBB.cmake
@@ -175,12 +175,12 @@ if(NOT TBB_FOUND)
     find_library(TBB_${_comp}_LIBRARY_RELEASE ${_comp}
         HINTS ${TBB_LIBRARY} ${TBB_SEARCH_DIR}
         PATHS ${TBB_DEFAULT_SEARCH_DIR}
-        PATH_SUFFIXES "${TBB_LIB_PATH_SUFFIX}")
+        PATH_SUFFIXES ${TBB_LIB_PATH_SUFFIX})
 
     find_library(TBB_${_comp}_LIBRARY_DEBUG ${_comp}_debug
         HINTS ${TBB_LIBRARY} ${TBB_SEARCH_DIR}
         PATHS ${TBB_DEFAULT_SEARCH_DIR} ENV LIBRARY_PATH
-        PATH_SUFFIXES "${TBB_LIB_PATH_SUFFIX}")
+        PATH_SUFFIXES ${TBB_LIB_PATH_SUFFIX})
     
     
     # Set the library to be used for the component


### PR DESCRIPTION
As the `TBB_LIB_PATH_SUFFIX` is a semicolon seperated list on Windows, the double quotes have to be removed when expanding the variable. Else, the call to `find_library` will search for the single concatenated `PATH_SUFFIXES` and will not find anything at all.
PS: For me it works on Windows with this change (see your issue #1).
