### PR TITLE
for cmake3 make tbb an imported target

### DIFF
--- a/FindTBB.cmake
+++ b/FindTBB.cmake
@@ -263,11 +263,13 @@ if(NOT TBB_FOUND)
   ##################################
 
   if(NOT CMAKE_VERSION VERSION_LESS 3.0 AND TBB_FOUND)
-    add_library(tbb INTERFACE)
-    target_include_directories(tbb INTERFACE ${TBB_INCLUDE_DIRS})
+    add_library(tbb UNKNOWN IMPORTED)
+    set_target_properties(tbb PROPERTIES INTERFACE_INCLUDE_DIRECTORIES ${TBB_INCLUDE_DIRS})
     if(TBB_LIBRARIES_RELEASE AND TBB_LIBRARIES_DEBUG)
-      target_compile_definitions(tbb INTERFACE $<$<OR:$<CONFIG:Debug>,$<CONFIG:RelWithDebInfo>>:TBB_USE_DEBUG=1>)
-      target_link_libraries(tbb INTERFACE $<$<OR:$<CONFIG:Debug>,$<CONFIG:RelWithDebInfo>>:${TBB_LIBRARIES_DEBUG}> $<$<OR:$<CONFIG:Release>,$<CONFIG:MinSizeRel>,$<CONFIG:>>:${TBB_LIBRARIES_RELEASE}>)
+      set_target_properties(tbb PROPERTIES
+          INTERFACE_COMPILE_DEFINITIONS "$<$<OR:$<CONFIG:Debug>,$<CONFIG:RelWithDebInfo>>:TBB_USE_DEBUG=1">
+          INTERFACE_LINK_LIBRARIES "$<$<OR:$<CONFIG:Debug>,$<CONFIG:RelWithDebInfo>>:${TBB_LIBRARIES_DEBUG}> $<$<OR:$<CONFIG:Release>,$<CONFIG:MinSizeRel>,$<CONFIG:>>:${TBB_LIBRARIES_RELEASE}>">
+          )
     elseif(TBB_LIBRARIES_RELEASE)
       target_link_libraries(tbb INTERFACE ${TBB_LIBRARIES_RELEASE})
     else()

--- a/FindTBB.cmake
+++ b/FindTBB.cmake
@@ -267,14 +267,19 @@ if(NOT TBB_FOUND)
     set_target_properties(tbb PROPERTIES INTERFACE_INCLUDE_DIRECTORIES ${TBB_INCLUDE_DIRS})
     if(TBB_LIBRARIES_RELEASE AND TBB_LIBRARIES_DEBUG)
       set_target_properties(tbb PROPERTIES
-          INTERFACE_COMPILE_DEFINITIONS "$<$<OR:$<CONFIG:Debug>,$<CONFIG:RelWithDebInfo>>:TBB_USE_DEBUG=1">
-          INTERFACE_LINK_LIBRARIES "$<$<OR:$<CONFIG:Debug>,$<CONFIG:RelWithDebInfo>>:${TBB_LIBRARIES_DEBUG}> $<$<OR:$<CONFIG:Release>,$<CONFIG:MinSizeRel>,$<CONFIG:>>:${TBB_LIBRARIES_RELEASE}>">
+          INTERFACE_COMPILE_DEFINITIONS "$<$<OR:$<CONFIG:Debug>,$<CONFIG:RelWithDebInfo>>:TBB_USE_DEBUG=1>"
+          IMPORTED_LOCATION_DEBUG          ${TBB_LIBRARIES_DEBUG}
+          IMPORTED_LOCATION_RELWITHDEBINFO ${TBB_LIBRARIES_DEBUG}
+          IMPORTED_LOCATION_RELEASE        ${TBB_LIBRARIES_RELEASE}
+          IMPORTED_LOCATION_MINSIZEREL     ${TBB_LIBRARIES_RELEASE}
           )
     elseif(TBB_LIBRARIES_RELEASE)
-      target_link_libraries(tbb INTERFACE ${TBB_LIBRARIES_RELEASE})
+      set_target_properties(tbb PROPERTIES IMPORTED_LOCATION ${TBB_LIBRARIES_RELEASE})
     else()
-      target_compile_definitions(tbb INTERFACE ${TBB_DEFINITIONS_DEBUG})
-      target_link_libraries(tbb INTERFACE ${TBB_LIBRARIES_DEBUG})
+      set_target_properties(tbb PROPERTIES
+          INTERFACE_COMPILE_DEFINITIONS "${TBB_DEFINITIONS_DEBUG}"
+          IMPORTED_LOCATION              ${TBB_LIBRARIES_DEBUG}
+          )
     endif()
   endif()
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -67,3 +67,17 @@ target_link_libraries(test_tbb_a ${TBB_LIBRARIES})
 add_executable(test_tbb_b test_tbb.cc)
 target_compile_options(test_tbb_b PRIVATE "-std=c++11")
 target_link_libraries(test_tbb_b tbb)
+
+add_library(test_tbb_c test_tbb.cc)
+target_compile_options(test_tbb_c PRIVATE "-std=c++11")
+target_link_libraries(test_tbb_c tbb)
+
+install(TARGETS test_tbb_c
+        EXPORT depends
+        RUNTIME DESTINATION bin
+        LIBRARY DESTINATION lib
+        ARCHIVE DESTINATION lib
+        )
+install (EXPORT depends
+  FILE "testfindtbb-depends.cmake"
+  DESTINATION cmake)


### PR DESCRIPTION
addresses an error when exporting a target that depends on tbb

I described this error with more detail in #5. I am by no means a cmake expert, but I needed this change for my work, and I wanted to contribute back since I have found findTBB.cmake helpful.
