### PR TITLE
Updated to handle TBB installed from Brew

### DIFF
--- a/FindTBB.cmake
+++ b/FindTBB.cmake
@@ -147,7 +147,8 @@ if(NOT TBB_FOUND)
 
   elseif(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
     # OS X
-    set(TBB_DEFAULT_SEARCH_DIR "/opt/intel/tbb")
+    set(TBB_DEFAULT_SEARCH_DIR "/opt/intel/tbb"
+                               "/usr/local/opt/tbb")
     
     # TODO: Check to see which C++ library is being used by the compiler.
     if(NOT ${CMAKE_SYSTEM_VERSION} VERSION_LESS 13.0)


### PR DESCRIPTION
When TBB is installed by brew it goes to a different location than you specified,
so I added it as a second option to the default search path.

Signed-Off-By: James Till Matta